### PR TITLE
Adding missing gpxParser methods to the typescript class. 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -81,6 +81,44 @@ export type Link = {
   type: string
 }
 
+export type GeoJSONFeature = {
+  type: string
+  geometry: {
+      type: string
+      coordinates: Point[]
+  }
+  properties: {
+    name: any
+    cmt: any
+    desc: any
+    src: any | null
+    number: any | null
+    link: any | null
+    type: any | null
+    sym: any | null
+  }
+}
+
+export type GeoJSON = {
+  type: string
+  features: GeoJSONFeature[]
+  properties: {
+      name: any
+      desc: any
+      time: any
+      author: any
+      link: any
+  }
+}
+
+export type ElevationObject = {
+  max: any
+  min: any
+  pos: number | null
+  neg: number | null
+  avg: number | null
+}
+
 declare class GpxParser {
   xmlSource: string
   metadata: MetaData
@@ -88,7 +126,13 @@ declare class GpxParser {
   tracks: Track[]
   routes: Route[]
   parse(xml: string): any
-  getElementValue(element: Element, needle: string): any
+  getElementValue(element: Element, needle: string): Element
+  queryDirectSelector(element: Element, needle: string): Element
+  calculDistance(points: Point[]): Distance
+  calcDistanceBetween(wpt1: Point, wpt2: Point): number
+  calcElevation(points: Point[]): ElevationObject
+  calculSlope(points: Point[], cumul: number[]): number[]
+  toGeoJSON(): GeoJSON
 }
 
 export default GpxParser

--- a/index.d.ts
+++ b/index.d.ts
@@ -111,14 +111,6 @@ export type GeoJSON = {
   }
 }
 
-export type ElevationObject = {
-  max: any
-  min: any
-  pos: number | null
-  neg: number | null
-  avg: number | null
-}
-
 declare class GpxParser {
   xmlSource: string
   metadata: MetaData
@@ -130,7 +122,7 @@ declare class GpxParser {
   queryDirectSelector(element: Element, needle: string): Element
   calculDistance(points: Point[]): Distance
   calcDistanceBetween(wpt1: Point, wpt2: Point): number
-  calcElevation(points: Point[]): ElevationObject
+  calcElevation(points: Point[]): Elevation
   calculSlope(points: Point[], cumul: number[]): number[]
   toGeoJSON(): GeoJSON
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -126,7 +126,7 @@ declare class GpxParser {
   tracks: Track[]
   routes: Route[]
   parse(xml: string): any
-  getElementValue(element: Element, needle: string): Element
+  getElementValue(element: Element, needle: string): Element | null
   queryDirectSelector(element: Element, needle: string): Element
   calculDistance(points: Point[]): Distance
   calcDistanceBetween(wpt1: Point, wpt2: Point): number


### PR DESCRIPTION
The previous typescript implementation only exported 'gpxParser.parse' and 'gpxParser.getElementValue'. The purpose of this PR is to add the remaining functions to make typescript users happy.