### PR TITLE
parse function return fix

### DIFF
--- a/src/GPXParser.js
+++ b/src/GPXParser.js
@@ -177,6 +177,7 @@ gpxParser.prototype.parse = function (gpxstring) {
 
         keepThis.tracks.push(track);
     }
+    return keepThis;
 };
 
 /**


### PR DESCRIPTION
Parse function isn't returning the parsed object